### PR TITLE
added more guards to turn off openssl

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6,7 +6,9 @@
 #include <unistd.h>
 #include <netdb.h>
 #include <fcntl.h>
+#if AISL_WITH_SSL == 1
 #include <openssl/ssl.h>
+#endif
 
 #ifdef __APPLE__
 #include <sys/ioctl.h>

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5,7 +5,9 @@
  * Distributed under terms of the MIT license.
  */
 
+#if AISL_WITH_SSL == 1
 #include <openssl/err.h>
+#endif
 #include "str-utils.h"
 #include "instance.h"
 #include "ssl.h"

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -25,8 +25,8 @@
 
 #include <aisl/config.h>
 #include <aisl/types.h>
+#if AISL_WITH_SSL == 1
 #include <openssl/ssl.h>
-
 
 struct aisl_ssl {
 	char    *key_file;
@@ -50,5 +50,6 @@ aisl_ssl_get_ctx(struct aisl_ssl *ssl, void *p_instance);
 void
 aisl_ssl_free(struct aisl_ssl *ssl);
 
+#endif
 
 #endif /* !AISL_SSL_H */


### PR DESCRIPTION
While following the steps from https://youtu.be/fBi1K2y5kEM I found that it was no longer possible to fully remove the requirement for OpenSSL, this addresses that.